### PR TITLE
instructive example for 'puppet parser validate'

### DIFF
--- a/snack.pp
+++ b/snack.pp
@@ -1,14 +1,15 @@
-#/etc/puppetlabs/puppet/modules/snicker/snack.pp
- 
+#/tmp/non-module-path/snicker/snack.pp
+      
 class snicker::snack {
   jabberwock { 'gimble':
-    chortle => true,
-    brillig => 'frabjous',
-    birds   => ['jubjub', 'vorpal', "${wabe}"],
+    chortle => true,brillig
+    => 'frabjous',
+    birds   => ['jubjub', "$vorpal", wabe],
   }
-  galumphing { ['mome', 'rath']:
-    borogove => 'bandersnatch',
-    tulgey   => $uffish,
-    mimsy    => 'manxome',
+  galumphing { ['mome', "rath"]:
+    borogove  => bandersnatch,
+     tulgey  => $uffish,
+      mimsy => 'manxome',
   }
 }
+

--- a/truth.pp
+++ b/truth.pp
@@ -1,0 +1,19 @@
+if false {
+    notice("false is true")
+}
+
+if 'false' {
+    notice('"false" is true')
+}
+
+if 1 {
+    notice('1 is true')
+}
+
+if 0 {
+    notice('0 is true')
+}
+
+if $undefined {
+    notice("${undefined} is true")
+}


### PR DESCRIPTION
this passes 'puppet parser validate' flawlessly, but is completely meaningless and violates several things in the style guide. i use this in fundamentals for demonstrating the limitations of 'puppet parser validate'.
